### PR TITLE
fixed ordering problem by shuffling list in addition to sorting

### DIFF
--- a/pair-maker.py
+++ b/pair-maker.py
@@ -3,6 +3,8 @@
 David Smith - 2017
 """
 
+import random
+
 
 def make_better_pairs(num_days, students):
     """Print out some pairs for a given number of days."""
@@ -19,6 +21,7 @@ def make_better_pairs(num_days, students):
 
     for day in range(0, num_days):
         used = set()
+        random.shuffle(students)
         students = sorted(students, key=lambda x: sorted(student_dict[x].values())[-1], reverse=True)
 
         print('')


### PR DESCRIPTION
This may appear strange, but the shuffling before the sort helps with small # of days pairing so that in the first few days, the person who picked last is not picking last again (due to 'ties' when sorting).